### PR TITLE
Fix tests after login and ldap strategies removal

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,17 +62,17 @@ var rwMutex sync.RWMutex
 
 // Server configuration
 type Server struct {
-	Address                    string               `yaml:",omitempty"`
-	AuditLog                   bool                 `yaml:"audit_log,omitempty"` // When true, allows additional audit logging on Write operations
-	CORSAllowAll               bool                 `yaml:"cors_allow_all,omitempty"`
-	GzipEnabled                bool                 `yaml:"gzip_enabled,omitempty"`
-	MetricsEnabled             bool                 `yaml:"metrics_enabled,omitempty"`
-	MetricsPort                int                  `yaml:"metrics_port,omitempty"`
-	Port                       int                  `yaml:",omitempty"`
-	StaticContentRootDirectory string               `yaml:"static_content_root_directory,omitempty"`
-	WebFQDN                    string               `yaml:"web_fqdn,omitempty"`
-	WebRoot                    string               `yaml:"web_root,omitempty"`
-	WebSchema                  string               `yaml:"web_schema,omitempty"`
+	Address                    string `yaml:",omitempty"`
+	AuditLog                   bool   `yaml:"audit_log,omitempty"` // When true, allows additional audit logging on Write operations
+	CORSAllowAll               bool   `yaml:"cors_allow_all,omitempty"`
+	GzipEnabled                bool   `yaml:"gzip_enabled,omitempty"`
+	MetricsEnabled             bool   `yaml:"metrics_enabled,omitempty"`
+	MetricsPort                int    `yaml:"metrics_port,omitempty"`
+	Port                       int    `yaml:",omitempty"`
+	StaticContentRootDirectory string `yaml:"static_content_root_directory,omitempty"`
+	WebFQDN                    string `yaml:"web_fqdn,omitempty"`
+	WebRoot                    string `yaml:"web_root,omitempty"`
+	WebSchema                  string `yaml:"web_schema,omitempty"`
 }
 
 // Auth provides authentication data for external services
@@ -435,7 +435,7 @@ func NewConfig() (c *Config) {
 			SigningKey:        "kiali",
 		},
 		Server: Server{
-			AuditLog: true,
+			AuditLog:                   true,
 			GzipEnabled:                true,
 			MetricsEnabled:             true,
 			MetricsPort:                9090,
@@ -466,7 +466,6 @@ func Set(conf *Config) {
 	defer rwMutex.Unlock()
 	configuration = *conf
 }
-
 
 // String marshals the given Config into a YAML string
 // WARNING: do NOT use the result of this function to retrieve any configuration: some fields are obfuscated for security reasons.

--- a/config/config.go
+++ b/config/config.go
@@ -467,14 +467,6 @@ func Set(conf *Config) {
 	configuration = *conf
 }
 
-func getDefaultStringFromFile(filename string, defaultValue string) (retVal string) {
-	if fileContents, err := ioutil.ReadFile(filename); err == nil {
-		retVal = string(fileContents)
-	} else {
-		retVal = defaultValue
-	}
-	return
-}
 
 // String marshals the given Config into a YAML string
 // WARNING: do NOT use the result of this function to retrieve any configuration: some fields are obfuscated for security reasons.

--- a/config/token.go
+++ b/config/token.go
@@ -75,16 +75,6 @@ func GenerateToken(username string) (TokenGenerated, error) {
 	return TokenGenerated{Token: ss, ExpiresOn: timeExpire, Username: username}, nil
 }
 
-// ValidateToken checks if the input token is still valid
-func ValidateToken(tokenString string) (string, error) {
-	claims, err := GetTokenClaimsIfValid(tokenString)
-	if err != nil {
-		return "", err
-	}
-
-	return claims.Subject, nil
-}
-
 func GetTokenClaimsIfValid(tokenString string) (*IanaClaims, error) {
 	token, err := jwt.ParseWithClaims(tokenString, &IanaClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte(GetSigningKey()), nil

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -499,16 +499,6 @@ func checkTokenSession(w http.ResponseWriter, r *http.Request) (int, string) {
 	return http.StatusUnauthorized, ""
 }
 
-func writeAuthenticateHeader(w http.ResponseWriter, r *http.Request) {
-	// If header exists return the value, must be 1 to use the API from Kiali
-	// Otherwise an empty string is returned and WWW-Authenticate will be Basic
-	if r.Header.Get("X-Auth-Type-Kiali-UI") == "1" {
-		w.Header().Set("WWW-Authenticate", "xBasic realm=\"Kiali\"")
-	} else {
-		w.Header().Set("WWW-Authenticate", "Basic realm=\"Kiali\"")
-	}
-}
-
 func NewAuthenticationHandler() (AuthenticationHandler, error) {
 	// Read token from the filesystem
 	saToken, err := kubernetes.GetKialiToken()

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -116,7 +116,7 @@ func TestStrategyTokenInvalidSignature(t *testing.T) {
 
 	// This `tokenString` should be valid for Kiali server because we generated
 	// it using the right functions. It's also already signed.
-	tokenString, err := config.GetSignedTokenString(tokenClaims)
+	tokenString, _ := config.GetSignedTokenString(tokenClaims)
 
 	// Let's create a hacked token with a mutated payload. The header and signature of the
 	// token will be kept unchanged.
@@ -388,7 +388,6 @@ func TestLogout(t *testing.T) {
 	assert.True(t, cookie.Expires.Before(clockTime))
 }
 
-
 func mockK8s(reject bool) {
 	k8s := kubetest.NewK8SClientMock()
 	prom := new(prometheustest.PromClientMock)
@@ -396,7 +395,7 @@ func mockK8s(reject bool) {
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	business.SetWithBackends(mockClientFactory, prom)
 
-	if (reject) {
+	if reject {
 		k8s.On("GetProjects", mock.AnythingOfType("string")).Return([]osproject_v1.Project{}, fmt.Errorf("Rejecting"))
 	} else {
 		k8s.On("GetProjects", mock.AnythingOfType("string")).Return([]osproject_v1.Project{

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -7,14 +7,21 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus/prometheustest"
 	"github.com/kiali/kiali/util"
 )
 
@@ -23,20 +30,27 @@ type dummyHandler struct {
 
 func (t dummyHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
 
-// TestStrategyLoginAuthentication checks that a user with no active
+// TestStrategyTokenAuthentication checks that a user with no active
 // session is logged in successfully
-func TestStrategyLoginAuthentication(t *testing.T) {
+func TestStrategyTokenAuthentication(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
 	cfg.Auth.Strategy = config.AuthStrategyToken
 	cfg.LoginToken.SigningKey = util.RandomString(10)
+	cfg.KubernetesConfig.CacheEnabled = false
 	config.Set(cfg)
 
 	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	util.Clock = util.ClockMock{Time: clockTime}
 
-	request := httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
-	request.SetBasicAuth("foo", "bar")
+	// Mock K8S API to accept credentials
+	mockK8s(false)
+
+	// Create request
+	form := url.Values{}
+	form.Add("token", "foo")
+	request := httptest.NewRequest("POST", "http://kiali/api/authenticate", nil)
+	request.PostForm = form
 
 	// Add a stale token to the request. Authentication should succeed even if a stale
 	// session is present. This prevents the user form manually clean browser cookies.
@@ -58,14 +72,23 @@ func TestStrategyLoginAuthentication(t *testing.T) {
 	assert.Equal(t, config.TokenCookieName, cookie.Name)
 	assert.True(t, cookie.HttpOnly)
 
-	newToken, _ := config.GenerateToken("foo")
-	assert.Equal(t, cookie.Value, newToken.Token)
+	// Build the token that we known we should receive
+	newToken, _ := config.GetSignedTokenString(config.IanaClaims{
+		SessionId: "foo",
+		StandardClaims: jwt.StandardClaims{
+			Subject:   "token",
+			ExpiresAt: clockTime.Add(time.Second * time.Duration(config.Get().LoginToken.ExpirationSeconds)).Unix(),
+			Issuer:    config.AuthStrategyTokenIssuer,
+		},
+	})
+
+	assert.Equal(t, cookie.Value, newToken)
 	assert.Equal(t, clockTime.Add(time.Second*time.Duration(cfg.LoginToken.ExpirationSeconds)), cookie.Expires)
 }
 
-// TestStrategyLoginInvalidSignature checks that an altered JWT token is
+// TestStrategyTokenInvalidSignature checks that an altered JWT token is
 // rejected as a valid authentication
-func TestStrategyLoginInvalidSignature(t *testing.T) {
+func TestStrategyTokenInvalidSignature(t *testing.T) {
 	// Set some config values to a known state
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
@@ -80,40 +103,30 @@ func TestStrategyLoginInvalidSignature(t *testing.T) {
 		return util.Clock.Now()
 	}
 
-	// First go through authentication to get a kiali cookie.
-	authRequest := httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
-	authRequest.SetBasicAuth("foo", "bar")
+	// First generate a "valid" token.
+	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(cfg.LoginToken.ExpirationSeconds))
+	tokenClaims := config.IanaClaims{
+		SessionId: "dummy",
+		StandardClaims: jwt.StandardClaims{
+			Subject:   "dummy",
+			ExpiresAt: timeExpire.Unix(),
+			Issuer:    config.AuthStrategyTokenIssuer,
+		},
+	}
 
-	responseRecorder := httptest.NewRecorder()
-	Authenticate(responseRecorder, authRequest)
-	response := responseRecorder.Result()
+	// This `tokenString` should be valid for Kiali server because we generated
+	// it using the right functions. It's also already signed.
+	tokenString, err := config.GetSignedTokenString(tokenClaims)
 
-	assert.Equal(t, http.StatusOK, response.StatusCode)
-	assert.Len(t, response.Cookies(), 1)
-
-	// Decode the JWT token in the cookie
-	cookie := response.Cookies()[0]
-	assert.Equal(t, config.TokenCookieName, cookie.Name)
-
-	token, err := jwt.ParseWithClaims(cookie.Value, &config.IanaClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte(config.GetSigningKey()), nil
-	})
-
-	assert.Nil(t, err)
-	assert.True(t, token.Valid) // Sanity check. The token should always be valid.
-
-	// Get the raw token
-	tokenString := token.Raw
-
-	// OK, authentication succeeded and we have a token.
 	// Let's create a hacked token with a mutated payload. The header and signature of the
 	// token will be kept unchanged.
 
 	// Build custom claims
-	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(60)) // 1 minute expiration from now
+	timeExpire = util.Clock.Now().Add(time.Second * time.Duration(60)) // 1 minute expiration from now
 	customClaims := config.IanaClaims{
+		SessionId: "dummy",
 		StandardClaims: jwt.StandardClaims{
-			Subject:   "foo", // We use the "foo" user which should be valid
+			Subject:   "dummy",
 			ExpiresAt: timeExpire.Unix(),
 			Issuer:    config.AuthStrategyTokenIssuer,
 		},
@@ -155,7 +168,7 @@ func TestStrategyLoginInvalidSignature(t *testing.T) {
 	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
 }
 
-// TestStrategyLoginValidatesExpiration checks that the Kiali back-end is
+// TestStrategyTokenValidatesExpiration checks that the Kiali back-end is
 // correctly checking the expiration time of the Kiali token.
 //
 // Assuming that a malicious user has stolen the Kiali token of a user,
@@ -163,7 +176,7 @@ func TestStrategyLoginInvalidSignature(t *testing.T) {
 // date of the token and the browser's cookie should be in sync. But a malicious
 // user may want to create his own cookie and use with the stolen token. Because
 // of this, the Kiali backend must check the expiration Claim of the JWT token.
-func TestStrategyLoginValidatesExpiration(t *testing.T) {
+func TestStrategyTokenValidatesExpiration(t *testing.T) {
 	// Set some config values to a known state
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
@@ -181,6 +194,7 @@ func TestStrategyLoginValidatesExpiration(t *testing.T) {
 	// Let's create a valid but expired token.
 	timeExpire := util.Clock.Now().Add(-time.Second * time.Duration(1)) // Expiration time is one second in the past
 	customClaims := config.IanaClaims{
+		SessionId: "dummy",
 		StandardClaims: jwt.StandardClaims{
 			Subject:   "foo",
 			ExpiresAt: timeExpire.Unix(),
@@ -212,68 +226,17 @@ func TestStrategyLoginValidatesExpiration(t *testing.T) {
 	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
 }
 
-// TestStrategyLoginValidatesUserChange checks that the Kiali back-end is verifying that
-// the user specified in a Kiali token matches to the user in the configuration.
-// This is for a scenario where logged in users should be kicked if an administrator
-// changes the Kiali configuration.
-func TestStrategyLoginValidatesUserChange(t *testing.T) {
-	// Set some config values to a known state
-	rand.Seed(time.Now().UnixNano())
-	cfg := config.NewConfig()
-	cfg.Auth.Strategy = config.AuthStrategyToken
-	cfg.LoginToken.SigningKey = util.RandomString(10)
-	config.Set(cfg)
-
-	// Mock the clock
-	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	util.Clock = util.ClockMock{Time: clockTime}
-	jwt.TimeFunc = func() time.Time {
-		return util.Clock.Now()
-	}
-
-	// Let's create a valid token with a user not matching the one from the config.
-	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(1))
-	customClaims := config.IanaClaims{
-		StandardClaims: jwt.StandardClaims{
-			Subject:   "dummy", // wrong user
-			ExpiresAt: timeExpire.Unix(),
-			Issuer:    config.AuthStrategyTokenIssuer,
-		},
-	}
-
-	token, _ := config.GetSignedTokenString(customClaims)
-
-	// Let's simulate a request
-	request := httptest.NewRequest("GET", "http://kiali/api/foo", nil)
-	cookie := http.Cookie{
-		Name:  config.TokenCookieName,
-		Value: token,
-	}
-	request.AddCookie(&cookie)
-
-	authenticationHandler, _ := NewAuthenticationHandler()
-	handler := authenticationHandler.Handle(new(dummyHandler))
-
-	responseRecorder := httptest.NewRecorder()
-	handler.ServeHTTP(responseRecorder, request)
-	response := responseRecorder.Result()
-
-	// Server should return an unauthorized response code.
-	// Body should be the text explanation of the HTTP error
-	body, _ := ioutil.ReadAll(response.Body)
-	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
-	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
-}
-
-// TestStrategyLoginMissingUser checks that the Kiali back-end is ensuring
+// TestStrategyTokenMissingUser checks that the Kiali back-end is ensuring
 // that the username field is populated in the Kiali auth token.
-func TestStrategyLoginMissingUser(t *testing.T) {
+func TestStrategyTokenMissingUser(t *testing.T) {
 	// Set some config values to a known state
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
+	cfg.KubernetesConfig.CacheEnabled = false
 	cfg.Auth.Strategy = config.AuthStrategyToken
 	cfg.LoginToken.SigningKey = util.RandomString(10)
 	config.Set(cfg)
+	mockK8s(false)
 
 	// Mock the clock
 	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -282,11 +245,11 @@ func TestStrategyLoginMissingUser(t *testing.T) {
 		return util.Clock.Now()
 	}
 
-	// Let's create a valid token without subject.
+	// Let's create a valid token without SessionId.
 	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(1))
 	customClaims := config.IanaClaims{
 		StandardClaims: jwt.StandardClaims{
-			// Subject:   "foo",
+			Subject:   "foo",
 			ExpiresAt: timeExpire.Unix(),
 			Issuer:    config.AuthStrategyTokenIssuer,
 		},
@@ -316,9 +279,9 @@ func TestStrategyLoginMissingUser(t *testing.T) {
 	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
 }
 
-// TestStrategyLoginMissingExpiration checks that the Kiali back-end is ensuring
+// TestStrategyTokenMissingExpiration checks that the Kiali back-end is ensuring
 // that the expiration date claim is populated in the Kiali auth token.
-func TestStrategyLoginMissingExpiration(t *testing.T) {
+func TestStrategyTokenMissingExpiration(t *testing.T) {
 	// Set some config values to a known state
 	rand.Seed(time.Now().UnixNano())
 	cfg := config.NewConfig()
@@ -359,109 +322,22 @@ func TestStrategyLoginMissingExpiration(t *testing.T) {
 	assert.Equal(t, fmt.Sprintln(http.StatusText(http.StatusUnauthorized)), string(body))
 }
 
-// TestStrategyLoginFails checks that a login attempt is
+// TestStrategyTokenFails checks that a login attempt is
 // rejected if user provides wrong credentials
-func TestStrategyLoginFails(t *testing.T) {
+func TestStrategyTokenFails(t *testing.T) {
 	cfg := config.NewConfig()
+	cfg.KubernetesConfig.CacheEnabled = false
 	cfg.Auth.Strategy = config.AuthStrategyToken
 	config.Set(cfg)
 
-	// Check wrong user
-	request := httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
-	request.SetBasicAuth("jdoe", "bar")
+	// Mock k8s API to reject authentication
+	mockK8s(true)
 
-	responseRecorder := httptest.NewRecorder()
-	Authenticate(responseRecorder, request)
-	response := responseRecorder.Result()
-
-	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
-	assert.Len(t, response.Cookies(), 0)
-
-	// Check wrong password
-	request = httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
-	request.SetBasicAuth("foo", "baz")
-
-	responseRecorder = httptest.NewRecorder()
-	Authenticate(responseRecorder, request)
-	response = responseRecorder.Result()
-
-	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
-	assert.Len(t, response.Cookies(), 0)
-}
-
-// TestStrategyLoginExtend checks that a user with an active session
-// received a refreshed token to extend his session time
-func TestStrategyLoginExtend(t *testing.T) {
-	jwt.TimeFunc = func() time.Time {
-		return util.Clock.Now()
-	}
-
-	rand.Seed(time.Now().UnixNano())
-	cfg := config.NewConfig()
-	cfg.Auth.Strategy = config.AuthStrategyToken
-	cfg.LoginToken.SigningKey = util.RandomString(10)
-	config.Set(cfg)
-
-	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	util.Clock = util.ClockMock{Time: clockTime}
-
-	request := httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
-	currentToken, _ := config.GenerateToken("foo")
-	oldCookie := http.Cookie{
-		Name:  config.TokenCookieName,
-		Value: currentToken.Token,
-	}
-	request.AddCookie(&oldCookie)
-
-	clockTime.Add(time.Second * time.Duration(cfg.LoginToken.ExpirationSeconds-10))
-	util.Clock = util.ClockMock{Time: clockTime}
-
-	responseRecorder := httptest.NewRecorder()
-	Authenticate(responseRecorder, request)
-	response := responseRecorder.Result()
-
-	assert.Equal(t, http.StatusOK, response.StatusCode)
-	assert.Len(t, response.Cookies(), 1)
-
-	cookie := response.Cookies()[0]
-	assert.Equal(t, config.TokenCookieName, cookie.Name)
-	assert.True(t, cookie.HttpOnly)
-
-	expectedToken, _ := config.GenerateToken("foo")
-	assert.NotEmpty(t, cookie.Value)
-	assert.Equal(t, expectedToken.Token, cookie.Value)
-	assert.Equal(t, clockTime.Add(time.Second*time.Duration(cfg.LoginToken.ExpirationSeconds)), cookie.Expires)
-}
-
-// TestStrategyLoginRejectStaleExtension checks that a stale
-// session (because of a signing key, username or password change) won't
-// be extended, but rejected as unauthorized.
-func TestStrategyLoginRejectStaleExtension(t *testing.T) {
-	jwt.TimeFunc = func() time.Time {
-		return util.Clock.Now()
-	}
-
-	rand.Seed(time.Now().UnixNano())
-	cfg := config.NewConfig()
-	cfg.Auth.Strategy = config.AuthStrategyToken
-	cfg.LoginToken.SigningKey = util.RandomString(10)
-	config.Set(cfg)
-
-	clockTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	util.Clock = util.ClockMock{Time: clockTime}
-
-	// If signing key has changed, session shouldn't be extended
-	request := httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
-	token, _ := config.GenerateToken("foo")
-	cfg.LoginToken.SigningKey = "myNewKey"
-	config.Set(cfg)
-
-	request = httptest.NewRequest("GET", "http://kiali/api/authenticate", nil)
-	oldCookie := http.Cookie{
-		Name:  config.TokenCookieName,
-		Value: token.Token,
-	}
-	request.AddCookie(&oldCookie)
+	// Send a request
+	form := url.Values{}
+	form.Add("token", "dummy")
+	request := httptest.NewRequest("POST", "http://kiali/api/authenticate", nil)
+	request.PostForm = form
 
 	responseRecorder := httptest.NewRecorder()
 	Authenticate(responseRecorder, request)
@@ -510,4 +386,25 @@ func TestLogout(t *testing.T) {
 
 	assert.Equal(t, "", cookie.Value)
 	assert.True(t, cookie.Expires.Before(clockTime))
+}
+
+
+func mockK8s(reject bool) {
+	k8s := kubetest.NewK8SClientMock()
+	prom := new(prometheustest.PromClientMock)
+
+	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
+	business.SetWithBackends(mockClientFactory, prom)
+
+	if (reject) {
+		k8s.On("GetProjects", mock.AnythingOfType("string")).Return([]osproject_v1.Project{}, fmt.Errorf("Rejecting"))
+	} else {
+		k8s.On("GetProjects", mock.AnythingOfType("string")).Return([]osproject_v1.Project{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "tutorial",
+				},
+			},
+		}, nil)
+	}
 }


### PR DESCRIPTION
Adapt tests in authentication_test.go file to run correctly using `token` strategy.
These tests were removed:
  - TestStrategyLoginValidatesUserChange, because the username isn't under Kiali control for `token` nor the other strategies. Username validation is delegated to the cluster API in the remaining strategies.
  - TestStrategyLoginExtend, because none of the remaining strategies accept extending the time of the session.
  - TestStrategyLoginRejectStaleExtension, because none of the remaining strategies accept extending the time of the session.

Also, remove unused funcs:
  - getDefaultStringFromFile in config.go
  - ValidateToken in token.go
  - writeAuthenticateHeader in authentication.go