### PR TITLE
Remove factory from testing cache

### DIFF
--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -165,11 +165,11 @@ type Discovery struct {
 }
 
 // NewDiscovery initializes a new Discovery.
-func NewDiscovery(kialiSAClients map[string]kubernetes.ClientInterface, cache cache.KialiCache, conf *config.Config) *Discovery {
+func NewDiscovery(clients map[string]kubernetes.ClientInterface, cache cache.KialiCache, conf *config.Config) *Discovery {
 	return &Discovery{
 		conf:           conf,
 		kialiCache:     cache,
-		kialiSAClients: kialiSAClients,
+		kialiSAClients: clients,
 	}
 }
 

--- a/istio/discovery_internal_test.go
+++ b/istio/discovery_internal_test.go
@@ -171,9 +171,9 @@ func TestIstioConfigMapName(t *testing.T) {
 				FakeCertificateConfigMap("istio-system"),
 			)
 
-			clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+			clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
 			cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-			discovery := NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+			discovery := NewDiscovery(clients, cache, conf)
 			kubeCache, err := cache.GetKubeCache(conf.KubernetesConfig.ClusterName)
 			require.NoError(err)
 

--- a/istio/discovery_test.go
+++ b/istio/discovery_test.go
@@ -188,9 +188,9 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 		},
 	}
 
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
 	cache := cache.NewTestingCache(t, k8s, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 
 	a, err := discovery.Clusters()
 	require.Nil(err, "GetClusters returned error: %v", err)
@@ -246,12 +246,12 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 			},
 		},
 	}
-	clients := map[string]kubernetes.UserClientInterface{
+	clients := map[string]kubernetes.ClientInterface{
 		"KialiCluster":                    remoteClient,
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(),
 	}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 
 	a, err := discovery.Clusters()
 	check.Nil(err, "GetClusters returned error: %v", err)
@@ -412,8 +412,8 @@ trustDomain: cluster.local
 	)
 	cache := cache.NewTestingCache(t, k8s, *conf)
 
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 1)
@@ -467,8 +467,8 @@ trustDomain: cluster.local
 	)
 	cache := cache.NewTestingCache(t, k8s, *conf)
 
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 1)
@@ -607,8 +607,8 @@ func TestMeshResolvesNetwork(t *testing.T) {
 			)
 			cache := cache.NewTestingCache(t, k8s, *conf)
 
-			clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
-			discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+			clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+			discovery := istio.NewDiscovery(clients, cache, conf)
 			mesh, err := discovery.Mesh(context.TODO())
 			require.NoError(err)
 			require.Len(mesh.ControlPlanes, 1)
@@ -681,8 +681,8 @@ trustDomain: cluster.local
 		FakeCertificateConfigMap("istio-system"),
 	)
 
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache.NewTestingCache(t, k8s, *conf), conf)
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	discovery := istio.NewDiscovery(clients, cache.NewTestingCache(t, k8s, *conf), conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 2)
@@ -706,7 +706,7 @@ trustDomain: cluster.local
 	// config.Set(conf)
 	// Create a new cache to clear the old mesh object.
 	cache := cache.NewTestingCache(t, k8s, *conf)
-	discovery = istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery = istio.NewDiscovery(clients, cache, conf)
 	mesh, err = discovery.Mesh(context.TODO())
 	require.NoError(err)
 
@@ -752,9 +752,9 @@ trustDomain: cluster.local
 		kubetest.FakeNamespace("bookinfo"),
 	)
 
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s, "remote": remoteClient}
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s, "remote": remoteClient}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 1)
@@ -805,9 +805,9 @@ trustDomain: cluster.local
 		FakeCertificateConfigMap("istio-system"),
 	)
 
-	clients := map[string]kubernetes.UserClientInterface{"east": eastClient, "remote": remoteClient}
+	clients := map[string]kubernetes.ClientInterface{"east": eastClient, "remote": remoteClient}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 1)
@@ -859,9 +859,9 @@ trustDomain: cluster.local
 		FakeCertificateConfigMap("istio-system"),
 	)
 
-	clients := map[string]kubernetes.UserClientInterface{"east": eastClient, "remote": remoteClient}
+	clients := map[string]kubernetes.ClientInterface{"east": eastClient, "remote": remoteClient}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 1)
@@ -904,9 +904,9 @@ trustDomain: cluster.local
 		FakeCertificateConfigMap("istio-system"),
 	)
 
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: eastClient, "west": westClient}
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: eastClient, "west": westClient}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 2)
@@ -975,14 +975,14 @@ trustDomain: cluster.local
 		kubetest.FakeNamespace("bookinfo"),
 	)
 
-	clients := map[string]kubernetes.UserClientInterface{
+	clients := map[string]kubernetes.ClientInterface{
 		"east":        eastClient,
 		"east-remote": eastRemoteClient,
 		"west":        westClient,
 		"west-remote": westRemoteClient,
 	}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 2)
@@ -1066,14 +1066,14 @@ trustDomain: cluster.local
 		kubetest.FakeNamespace("bookinfo"),
 	)
 
-	clients := map[string]kubernetes.UserClientInterface{
+	clients := map[string]kubernetes.ClientInterface{
 		"controlplane":     controlPlaneClient,
 		"dataplane":        dataPlaneClient,
 		"dataplane-remote": dataPlaneRemoteClient,
 	}
 
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 2)
@@ -1112,9 +1112,9 @@ func TestGetClustersShowsConfiguredKialiInstances(t *testing.T) {
 		URL:          "kiali.istio-system.west",
 	}}
 
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient()}
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient()}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 
 	clusters, err := discovery.Clusters()
 
@@ -1165,9 +1165,9 @@ deployment:
 		kubetest.FakeNamespace("istio-system"),
 		kialiService,
 	)
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	clusters, err := discovery.Clusters()
 
 	require.NoError(err)
@@ -1190,9 +1190,9 @@ func TestAddingKialiInstanceToExistingClusterDoesntAddNewCluster(t *testing.T) {
 	}}
 
 	k8s := kubetest.NewFakeK8sClient()
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	clusters, err := discovery.Clusters()
 
 	require.NoError(err)
@@ -1235,9 +1235,9 @@ trustDomain: cluster.local
 		kubetest.FakeNamespace("bookinfo"),
 	)
 
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s, "remote": remoteClient}
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s, "remote": remoteClient}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 
 	require.True(discovery.IsRemoteCluster(context.Background(), "remote"))
 	require.False(discovery.IsRemoteCluster(context.Background(), "east"))
@@ -1436,9 +1436,9 @@ func TestIstiodResourceThresholds(t *testing.T) {
 				},
 			)
 
-			clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+			clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
 			cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-			discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+			discovery := istio.NewDiscovery(clients, cache, conf)
 
 			mesh, err := discovery.Mesh(context.Background())
 			if testCase.expectedErr != nil {
@@ -1502,7 +1502,7 @@ trustDomain: cluster.local
 }
 
 type fakeForwarder struct {
-	kubernetes.UserClientInterface
+	kubernetes.ClientInterface
 	testURL string
 }
 
@@ -1546,7 +1546,7 @@ func TestCanConnectToIstiod(t *testing.T) {
 
 	testServer := istiodTestServer(t)
 	fakeForwarder := &fakeForwarder{
-		UserClientInterface: kubetest.NewFakeK8sClient(
+		ClientInterface: kubetest.NewFakeK8sClient(
 			runningIstiodPod("default"),
 			fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false),
 			fakeIstioConfigMap("default"),
@@ -1556,10 +1556,10 @@ func TestCanConnectToIstiod(t *testing.T) {
 		testURL: testServer.URL,
 	}
 
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
+	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = fakeForwarder
 	cache := cache.NewTestingCacheWithClients(t, k8sclients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(k8sclients), cache, conf)
+	discovery := istio.NewDiscovery(k8sclients, cache, conf)
 
 	mesh, err := discovery.Mesh(context.Background())
 	require.NoError(err)
@@ -1568,7 +1568,7 @@ func TestCanConnectToIstiod(t *testing.T) {
 }
 
 type badForwarder struct {
-	kubernetes.UserClientInterface
+	kubernetes.ClientInterface
 }
 
 func (f *badForwarder) ForwardGetRequest(namespace, podName string, destinationPort int, path string) ([]byte, error) {
@@ -1582,7 +1582,7 @@ func TestCanConnectToUnreachableIstiod(t *testing.T) {
 	conf := config.NewConfig()
 
 	fakeForwarder := &badForwarder{
-		UserClientInterface: kubetest.NewFakeK8sClient(
+		ClientInterface: kubetest.NewFakeK8sClient(
 			runningIstiodPod("default"),
 			fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false),
 			fakeIstioConfigMap("default"),
@@ -1591,10 +1591,10 @@ func TestCanConnectToUnreachableIstiod(t *testing.T) {
 		),
 	}
 
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
+	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = fakeForwarder
 	cache := cache.NewTestingCacheWithClients(t, k8sclients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(k8sclients), cache, conf)
+	discovery := istio.NewDiscovery(k8sclients, cache, conf)
 
 	mesh, err := discovery.Mesh(context.Background())
 	require.NoError(err)
@@ -1631,14 +1631,14 @@ func TestUpdateStatusMultipleRevsWithoutHealthyPods(t *testing.T) {
 
 	testServer := istiodTestServer(t)
 	fakeForwarder := &fakeForwarder{
-		UserClientInterface: k8s,
-		testURL:             testServer.URL,
+		ClientInterface: k8s,
+		testURL:         testServer.URL,
 	}
 
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
+	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = fakeForwarder
 	cache := cache.NewTestingCacheWithClients(t, k8sclients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(k8sclients), cache, conf)
+	discovery := istio.NewDiscovery(k8sclients, cache, conf)
 
 	mesh, err := discovery.Mesh(context.Background())
 	require.NoError(err)
@@ -1676,14 +1676,14 @@ func TestUpdateStatusMultipleHealthyRevs(t *testing.T) {
 
 	testServer := istiodTestServer(t)
 	fakeForwarder := &fakeForwarder{
-		UserClientInterface: k8s,
-		testURL:             testServer.URL,
+		ClientInterface: k8s,
+		testURL:         testServer.URL,
 	}
 
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
+	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = fakeForwarder
 	cache := cache.NewTestingCacheWithClients(t, k8sclients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(k8sclients), cache, conf)
+	discovery := istio.NewDiscovery(k8sclients, cache, conf)
 
 	mesh, err := discovery.Mesh(context.Background())
 	require.NoError(err)
@@ -1694,7 +1694,7 @@ func TestUpdateStatusMultipleHealthyRevs(t *testing.T) {
 }
 
 type accessReviewClient struct {
-	kubernetes.UserClientInterface
+	kubernetes.ClientInterface
 	AccessReview []*authv1.SelfSubjectAccessReview
 }
 
@@ -2170,17 +2170,17 @@ func TestDiscoverWithTags(t *testing.T) {
 				conf = *tc.conf
 			}
 
-			clients := make(map[string]kubernetes.UserClientInterface)
+			clients := make(map[string]kubernetes.ClientInterface)
 			for cluster, objects := range tc.setup() {
 				k8s := kubetest.NewFakeK8sClient(objects...)
 				client := &accessReviewClient{
-					UserClientInterface: k8s,
-					AccessReview:        []*authv1.SelfSubjectAccessReview{allowedToListWebhookReview},
+					ClientInterface: k8s,
+					AccessReview:    []*authv1.SelfSubjectAccessReview{allowedToListWebhookReview},
 				}
 				clients[cluster] = client
 			}
 			cache := cache.NewTestingCacheWithClients(t, clients, conf)
-			discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, &conf)
+			discovery := istio.NewDiscovery(clients, cache, &conf)
 
 			mesh, err := discovery.Mesh(context.Background())
 			require.NoError(err)
@@ -2243,12 +2243,12 @@ func TestDiscoverTagsWithoutWebhookPermissions(t *testing.T) {
 		FakeCertificateConfigMap("istio-system"),
 	)
 	client := &accessReviewClient{
-		UserClientInterface: k8s,
-		AccessReview:        []*authv1.SelfSubjectAccessReview{allowedToListWebhookReview},
+		ClientInterface: k8s,
+		AccessReview:    []*authv1.SelfSubjectAccessReview{allowedToListWebhookReview},
 	}
-	clients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: client}
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: client}
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 	require.False(cache.CanListWebhooks(conf.KubernetesConfig.ClusterName))
 
 	mesh, err := discovery.Mesh(context.TODO())
@@ -2257,9 +2257,9 @@ func TestDiscoverTagsWithoutWebhookPermissions(t *testing.T) {
 	require.Nil(mesh.ControlPlanes[0].Tag)
 }
 
-func approvingClient(client kubernetes.UserClientInterface) *accessReviewClient {
+func approvingClient(client kubernetes.ClientInterface) *accessReviewClient {
 	return &accessReviewClient{
-		UserClientInterface: client,
+		ClientInterface: client,
 		AccessReview: []*authv1.SelfSubjectAccessReview{
 			{
 				Spec: authv1.SelfSubjectAccessReviewSpec{
@@ -2306,7 +2306,7 @@ func TestDiscoverTagsWithExternalCluster(t *testing.T) {
 	tagProdRemote := fakeDefaultWebhook()
 	tagProdRemote.Labels[config.IstioRevisionLabel] = "1-23-0"
 	tagProdRemote.Labels[models.IstioTagLabel] = "prod"
-	clients := map[string]kubernetes.UserClientInterface{
+	clients := map[string]kubernetes.ClientInterface{
 		"external": approvingClient(kubetest.NewFakeK8sClient(
 			fakeDefaultWebhook(),
 			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
@@ -2326,7 +2326,7 @@ func TestDiscoverTagsWithExternalCluster(t *testing.T) {
 	}
 
 	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
-	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
+	discovery := istio.NewDiscovery(clients, cache, conf)
 
 	mesh, err := discovery.Mesh(context.TODO())
 	require.NoError(err)

--- a/istio/version_test.go
+++ b/istio/version_test.go
@@ -141,7 +141,7 @@ func TestParseIstioRawVersion(t *testing.T) {
 }
 
 type fakeForwarder struct {
-	kubernetes.UserClientInterface
+	kubernetes.ClientInterface
 	testURL string
 }
 
@@ -196,7 +196,7 @@ func TestGetVersionRemoteCluster(t *testing.T) {
 
 	testServer := istiodTestServer(t)
 
-	clients := map[string]kubernetes.UserClientInterface{
+	clients := map[string]kubernetes.ClientInterface{
 		"test-cluster": kubetest.NewFakeK8sClient(),
 		"remote-cluster": kubetest.NewFakeK8sClient(
 			runningIstiodPod(),
@@ -215,11 +215,10 @@ func TestGetVersionRemoteCluster(t *testing.T) {
 	}
 
 	clients["remote-cluster"] = &fakeForwarder{
-		UserClientInterface: clients["remote-cluster"],
-		testURL:             testServer.URL,
+		ClientInterface: clients["remote-cluster"],
+		testURL:         testServer.URL,
 	}
-	factory := kubetest.NewFakeClientFactory(conf, clients)
-	cache := cache.NewTestingCacheWithFactory(t, factory, *conf)
+	cache := cache.NewTestingCacheWithClients(t, clients, *conf)
 	kubeCache, err := cache.GetKubeCache("remote-cluster")
 	require.NoError(err)
 

--- a/kubernetes/cache/testing.go
+++ b/kubernetes/cache/testing.go
@@ -11,16 +11,15 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
-func newTestingCache(t testing.TB, cf kubernetes.ClientFactory, conf config.Config) KialiCache {
+func newTestingCache(t testing.TB, clients map[string]kubernetes.ClientInterface, conf config.Config) KialiCache {
 	t.Helper()
 	// Disabling Istio API for tests. Otherwise the cache will try and poll the Istio endpoint
 	// when the cache is created.
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
 
-	cache, err := newKialiCache(cf.GetSAClients(), conf, ConstantWaitForSync)
+	cache, err := newKialiCache(clients, conf, ConstantWaitForSync)
 	if err != nil {
 		t.Fatalf("Error creating KialiCache: %v", err)
 	}
@@ -31,24 +30,22 @@ func newTestingCache(t testing.TB, cf kubernetes.ClientFactory, conf config.Conf
 
 // NewTestingCache will create a cache for you from the kube client and will cleanup the cache
 // when the test ends.
-func NewTestingCache(t *testing.T, k8s kubernetes.UserClientInterface, conf config.Config) KialiCache {
+func NewTestingCache(t *testing.T, k8s kubernetes.ClientInterface, conf config.Config) KialiCache {
 	t.Helper()
-	cf := kubetest.NewFakeClientFactory(&conf, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
-	return newTestingCache(t, cf, conf)
+	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
+	return newTestingCache(t, clients, conf)
 }
 
 // NewTestingCacheWithFactory allows you to pass in a custom client factory. Good for testing multicluster.
 func NewTestingCacheWithFactory(t testing.TB, cf kubernetes.ClientFactory, conf config.Config) KialiCache {
 	t.Helper()
-	return newTestingCache(t, cf, conf)
+	return newTestingCache(t, cf.GetSAClients(), conf)
 }
 
 // NewTestingCacheWithClients allows you to pass in a map of clients instead of creating a client factory. Good for testing multicluster.
-func NewTestingCacheWithClients(t *testing.T, clients map[string]kubernetes.UserClientInterface, conf config.Config) KialiCache {
+func NewTestingCacheWithClients(t *testing.T, clients map[string]kubernetes.ClientInterface, conf config.Config) KialiCache {
 	t.Helper()
-	cf := kubetest.NewK8SClientFactoryMock(nil)
-	cf.SetClients(clients)
-	return newTestingCache(t, cf, conf)
+	return newTestingCache(t, clients, conf)
 }
 
 // ConstantWaitForSync waits continuously with zero interval. Only use this for testing.


### PR DESCRIPTION
### Describe the change

Some tests like `istio.Discovery`, shouldn't need to know the difference between `UserClientInterface` and `ClientInterface` and should just use `ClientInterface`. Updates the testing cache methods to make this possible.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
