### PR TITLE
Keep Prometheus enabled when unreachable at startup

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -95,27 +95,25 @@ func run(ctx context.Context, conf *config.Config, staticAssetFS fs.FS, clientFa
 
 	// Create shared prometheus client shared by all prometheus requests in the business layer.
 	// If enabled=true but the URL is empty, unreachable, or the transport fails to initialize,
-	// Kiali falls back to disabled mode rather than crashing: it injects a NoopClient, sets
-	// Enabled=false in the config, and records a DisabledReason for the UI to surface.
+	// Kiali injects a NoopClient and records a DisabledReason but keeps Enabled=true so that
+	// addon status checks and the mesh page still probe Prometheus and report the error.
 	var prom prometheus.ClientInterface
 	if conf.ExternalServices.Prometheus.Enabled {
 		var disabledReason string
 		if conf.ExternalServices.Prometheus.URL == "" {
-			disabledReason = "Prometheus URL is empty; falling back to disabled mode"
+			disabledReason = "Prometheus URL is empty; metrics features are unavailable"
 		} else {
 			client, err := prometheus.NewClient(*conf, kialiToken)
 			if err != nil {
-				disabledReason = fmt.Sprintf("Prometheus client init failed. Falling back to disabled mode. err=%s", err)
+				disabledReason = fmt.Sprintf("Prometheus client init failed: %s", err)
 			} else {
-				// Use the same health check approach as business/istio_status.go getAddonStatus:
-				// This works with Prometheus, Thanos, and other TSDB backends.
 				healthURL := conf.ExternalServices.Prometheus.HealthCheckUrl
 				if healthURL == "" {
 					healthURL = conf.ExternalServices.Prometheus.URL + "/-/healthy"
 				}
 				_, statusCode, _, probeErr := httputil.HttpGet(healthURL, &conf.ExternalServices.Prometheus.Auth, 10*time.Second, nil, nil, conf)
 				if probeErr != nil || statusCode > 399 {
-					disabledReason = fmt.Sprintf("Prometheus unreachable at [%s] (status [%d]). Falling back to disabled mode", healthURL, statusCode)
+					disabledReason = fmt.Sprintf("Prometheus unreachable at [%s] (status [%d])", healthURL, statusCode)
 				} else {
 					prom = client
 				}
@@ -123,7 +121,6 @@ func run(ctx context.Context, conf *config.Config, staticAssetFS fs.FS, clientFa
 		}
 		if disabledReason != "" {
 			log.Warningf("%s", disabledReason)
-			conf.ExternalServices.Prometheus.Enabled = false
 			conf.ExternalServices.Prometheus.DisabledReason = disabledReason
 			config.Set(conf)
 			prom = prometheus.NewNoopClient()

--- a/config/config.go
+++ b/config/config.go
@@ -339,12 +339,14 @@ type PrometheusConfig struct {
 	CacheEnabled    bool              `yaml:"cache_enabled,omitempty" json:"cacheEnabled,omitempty"`       // Enable cache for Prometheus queries
 	CacheExpiration int               `yaml:"cache_expiration,omitempty" json:"cacheExpiration,omitempty"` // Global cache expiration expressed in seconds
 	CustomHeaders   map[string]string `yaml:"custom_headers,omitempty" json:"customHeaders,omitempty"`
-	// DisabledReason is set at startup when Kiali auto-disables Prometheus due to an error (empty URL, transport
-	// failure, or unreachable endpoint). It is never serialized to config files or returned as part of the
-	// Prometheus config YAML -- it is an in-memory-only signal for the handlers layer to surface to the UI.
-	// When Enabled is false and DisabledReason is empty, the user explicitly disabled Prometheus in config.
-	// When Enabled is false and DisabledReason is non-empty, Kiali auto-disabled it and should warn the user.
-	DisabledReason string            `yaml:"-" json:"-"`             // in-memory only; never serialized to config files or API responses
+	// DisabledReason is set at startup when Prometheus is enabled but unavailable (empty URL, transport
+	// failure, or unreachable endpoint). Enabled remains true so that addon status checks and the mesh
+	// page still probe Prometheus and report errors. The handlers layer surfaces DisabledReason to the
+	// frontend via the /api/config endpoint so the UI can warn the user and hide metrics features.
+	// When Enabled is true and DisabledReason is empty, Prometheus is fully operational.
+	// When Enabled is true and DisabledReason is non-empty, Prometheus was requested but is unavailable.
+	// When Enabled is false, the user explicitly disabled Prometheus.
+	DisabledReason string            `yaml:"-" json:"-"`             // in-memory only; never serialized to config files
 	Enabled        bool              `yaml:"enabled" json:"enabled"` // no omitempty: false must be serialized to the frontend
 	HealthCheckUrl string            `yaml:"health_check_url,omitempty" json:"healthCheckUrl,omitempty"`
 	IsCore         bool              `yaml:"is_core,omitempty" json:"isCore,omitempty"`

--- a/frontend/src/app/AuthenticationController.tsx
+++ b/frontend/src/app/AuthenticationController.tsx
@@ -201,17 +201,17 @@ class AuthenticationControllerComponent extends React.Component<
       this.props.setChatAI(configs[1].data.chatAI);
       this.applyUIDefaults();
 
-      // Notify the user if Prometheus is disabled -- either by their choice or due to an auto-fallback.
-      if (!configs[1].data.prometheus.enabled) {
-        if (configs[1].data.prometheus.disabledReason) {
-          addWarning(configs[1].data.prometheus.disabledReason);
-        } else {
-          addInfo(
-            'Prometheus metrics store is disabled. Some features (graph, metrics, health) are unavailable.',
-            '',
-            false
-          );
-        }
+      // Notify the user about Prometheus availability.
+      if (configs[1].data.prometheus.disabledReason) {
+        // Prometheus is enabled but was unreachable at startup — warn the user.
+        addWarning(configs[1].data.prometheus.disabledReason);
+      } else if (!configs[1].data.prometheus.enabled) {
+        // Prometheus was explicitly disabled by the user.
+        addInfo(
+          'Prometheus metrics store is disabled. Some features (graph, metrics, health) are unavailable.',
+          '',
+          false
+        );
       }
 
       if (this.props.landingRoute) {

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -201,6 +201,10 @@ export const setServerConfig = (cfg: ServerConfig): void => {
   }
 };
 
+export const isPrometheusAvailable = (): boolean => {
+  return serverConfig.prometheus.enabled && !serverConfig.prometheus.disabledReason;
+};
+
 export const isIstioNamespace = (namespace: string): boolean => {
   return Object.values(serverConfig.controlPlanes).some(cpNamespace => cpNamespace === namespace);
 };

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -21,7 +21,7 @@ import { Paths } from './Paths';
 import { jaegerQuery } from './JaegerQuery';
 
 // ServerConfig
-import { homeCluster, isMultiCluster, serverConfig } from './ServerConfig';
+import { homeCluster, isMultiCluster, isPrometheusAvailable, serverConfig } from './ServerConfig';
 
 export {
   authenticationConfig,
@@ -34,6 +34,7 @@ export {
   kialiLogoDark,
   kialiIconLight,
   kialiIconDark,
+  isPrometheusAvailable,
   serverConfig,
   jaegerQuery
 };

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -24,7 +24,7 @@ import { ErrorSection } from '../../components/ErrorSection/ErrorSection';
 import { connectRefresh } from '../../components/Refresh/connectRefresh';
 import { HistoryManager } from 'app/History';
 import { basicTabStyle } from 'styles/TabStyles';
-import { serverConfig } from 'config';
+import { isPrometheusAvailable, serverConfig } from 'config';
 import { isGVKSupported } from '../../utils/IstioConfigUtils';
 import { getAppLabelName } from 'config/ServerConfig';
 import { setAIContext } from 'helpers/ChatAI';
@@ -226,7 +226,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     // Default tabs
     const tabsArray: React.ReactNode[] = [overTab];
     if (this.state.isSupported) {
-      if (serverConfig.prometheus.enabled) {
+      if (isPrometheusAvailable()) {
         tabsArray.push(trafficTab, inTab, outTab);
       }
       // Conditional Traces tab

--- a/frontend/src/pages/Graph/EmptyGraphLayout.tsx
+++ b/frontend/src/pages/Graph/EmptyGraphLayout.tsx
@@ -17,7 +17,7 @@ import { RefreshIntervalManual } from 'config/Config';
 import { IntervalInMilliseconds } from 'types/Common';
 import { t } from 'utils/I18nUtils';
 import { RunMode } from 'types/ServerConfig';
-import { serverConfig } from 'config';
+import { isPrometheusAvailable, serverConfig } from 'config';
 
 type EmptyGraphLayoutProps = {
   action?: any;
@@ -85,7 +85,7 @@ export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, Emp
   }
 
   render(): React.ReactNode {
-    if (!serverConfig.prometheus.enabled) {
+    if (!isPrometheusAvailable()) {
       return (
         <EmptyState
           headingLevel="h5"

--- a/frontend/src/pages/Graph/__tests__/EmptyGraphLayout.test.tsx
+++ b/frontend/src/pages/Graph/__tests__/EmptyGraphLayout.test.tsx
@@ -15,11 +15,26 @@ describe('EmptyGraphLayout', () => {
   };
 
   afterEach(() => {
-    setServerConfig({ ...serverConfig, prometheus: { ...serverConfig.prometheus, enabled: true } });
+    setServerConfig({
+      ...serverConfig,
+      prometheus: { ...serverConfig.prometheus, enabled: true, disabledReason: undefined }
+    });
   });
 
-  it('shows prometheus disabled message when prometheus is disabled', () => {
+  it('shows prometheus disabled message when prometheus is explicitly disabled', () => {
     setServerConfig({ ...serverConfig, prometheus: { ...serverConfig.prometheus, enabled: false } });
+
+    const wrapper = shallow(<EmptyGraphLayout {...defaultProps} />);
+
+    expect(wrapper.find('#empty-graph-prometheus-disabled').exists()).toBe(true);
+    expect(wrapper.html()).toContain('Metrics are disabled');
+  });
+
+  it('shows prometheus disabled message when prometheus is enabled but unreachable', () => {
+    setServerConfig({
+      ...serverConfig,
+      prometheus: { ...serverConfig.prometheus, enabled: true, disabledReason: 'Prometheus unreachable' }
+    });
 
     const wrapper = shallow(<EmptyGraphLayout {...defaultProps} />);
 

--- a/frontend/src/pages/Mesh/target/TargetPanelMetrics.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMetrics.tsx
@@ -18,7 +18,7 @@ import * as API from '../../../services/Api';
 import { addError } from '../../../utils/AlertUtils';
 import { computePrometheusRateParams } from '../../../services/Prometheus';
 import { IstioMetricsOptions } from '../../../types/MetricsOptions';
-import { serverConfig } from '../../../config';
+import { isPrometheusAvailable, serverConfig } from '../../../config';
 
 type TargetPanelMetricsProps<T extends MeshNodeData> = TargetPanelCommonProps & {
   target: NodeTarget<T>;
@@ -66,7 +66,7 @@ export const TargetPanelMetrics: React.FC<TargetPanelMetricsProps<MeshNodeData>>
   };
 
   React.useEffect(() => {
-    if (serverConfig.prometheus.enabled) {
+    if (isPrometheusAvailable()) {
       fetchMetrics();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -84,10 +84,10 @@ export const TargetPanelMetrics: React.FC<TargetPanelMetricsProps<MeshNodeData>>
       <div className={targetBodyStyle}>
         <span>{t('Version: {{version}}', { version: data.version || t(UNKNOWN) })}</span>
         {targetPanelHR}
-        {!serverConfig.prometheus.enabled && (
+        {!isPrometheusAvailable() && (
           <span>{t('Metrics are unavailable because the Prometheus metrics store is disabled.')}</span>
         )}
-        {serverConfig.prometheus.enabled && (
+        {isPrometheusAvailable() && (
           <TargetPanelControlPlaneMetrics
             key={data.namespace}
             istiodContainerMemory={metrics?.memory_usage}

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -33,7 +33,7 @@ import { connectRefresh } from '../../components/Refresh/connectRefresh';
 import { HistoryManager } from 'app/History';
 import { durationSelector } from 'store/Selectors';
 import { basicTabStyle } from 'styles/TabStyles';
-import { serverConfig } from 'config';
+import { isPrometheusAvailable, serverConfig } from 'config';
 import { getGVKTypeString } from '../../utils/IstioConfigUtils';
 import { gvkType } from '../../types/IstioConfigList';
 import { setAIContext } from 'helpers/ChatAI';
@@ -232,7 +232,7 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
       </Tab>
     );
 
-    const tabsArray: React.ReactNode[] = serverConfig.prometheus.enabled ? [overTab, trafficTab, inTab] : [overTab];
+    const tabsArray: React.ReactNode[] = isPrometheusAvailable() ? [overTab, trafficTab, inTab] : [overTab];
 
     if (this.props.tracingInfo && this.props.tracingInfo.enabled && this.props.tracingInfo.integration) {
       const fromWaypoint =

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -8,7 +8,7 @@ import { addError } from '../../utils/AlertUtils';
 import { IstioMetrics } from '../../components/Metrics/IstioMetrics';
 import { MetricsObjectTypes } from '../../types/Metrics';
 import { CustomMetrics } from '../../components/Metrics/CustomMetrics';
-import { getAppLabelName, getVersionLabelName, serverConfig } from '../../config/ServerConfig';
+import { getAppLabelName, getVersionLabelName, isPrometheusAvailable, serverConfig } from '../../config/ServerConfig';
 import { WorkloadPodLogs } from './WorkloadPodLogs';
 import { DurationInSeconds, TimeInMilliseconds, TimeRange } from '../../types/Common';
 import { KialiAppState } from '../../store/Store';
@@ -209,7 +209,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
         tabsArray.push(logTab);
       }
 
-      if (serverConfig.prometheus.enabled) {
+      if (isPrometheusAvailable()) {
         tabsArray.push(
           <Tab title="Traffic" eventKey={1} key="Traffic">
             <TrafficDetails

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -221,7 +221,7 @@ func getPrometheusConfig(conf *config.Config, client prometheus.ClientInterface,
 		GlobalScrapeInterval: defaultPrometheusGlobalScrapeInterval,
 		StorageTsdbRetention: defaultPrometheusGlobalStorageTSDBRetention,
 	}
-	if !conf.ExternalServices.Prometheus.Enabled || conf.RunMode == config.RunModeOffline {
+	if !conf.ExternalServices.Prometheus.Enabled || conf.ExternalServices.Prometheus.DisabledReason != "" || conf.RunMode == config.RunModeOffline {
 		return promConfig
 	}
 	// Check if thanosProxy

--- a/handlers/config_test.go
+++ b/handlers/config_test.go
@@ -106,12 +106,12 @@ func TestConfigHandlerPrometheusDisabled(t *testing.T) {
 	require.Empty(confResp.Prometheus.DisabledReason, "DisabledReason should be empty when user explicitly disabled Prometheus")
 }
 
-func TestConfigHandlerPrometheusAutoDisabled(t *testing.T) {
+func TestConfigHandlerPrometheusEnabledButUnreachable(t *testing.T) {
 	require := require.New(t)
 
 	conf := config.NewConfig()
-	conf.ExternalServices.Prometheus.Enabled = false
-	conf.ExternalServices.Prometheus.DisabledReason = "Prometheus unreachable at [http://prometheus:9090/-/healthy] (status [0]). Falling back to disabled mode"
+	conf.ExternalServices.Prometheus.Enabled = true
+	conf.ExternalServices.Prometheus.DisabledReason = "Prometheus unreachable at [http://prometheus:9090/-/healthy] (status [0])"
 	k8s := kubetest.NewFakeK8sClient()
 	cf := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
@@ -138,8 +138,8 @@ func TestConfigHandlerPrometheusAutoDisabled(t *testing.T) {
 	var confResp handlers.PublicConfig
 	require.NoError(json.Unmarshal(actual, &confResp))
 
-	require.False(confResp.Prometheus.Enabled, "Prometheus should be disabled")
-	require.NotEmpty(confResp.Prometheus.DisabledReason, "DisabledReason should be set when Kiali auto-disabled Prometheus")
+	require.True(confResp.Prometheus.Enabled, "Prometheus should still be enabled (user's intent)")
+	require.NotEmpty(confResp.Prometheus.DisabledReason, "DisabledReason should be set when Prometheus is unreachable")
 	require.Equal(conf.ExternalServices.Prometheus.DisabledReason, confResp.Prometheus.DisabledReason)
 }
 


### PR DESCRIPTION
## Summary

During review of #9633, I noticed that when Prometheus is enabled but unreachable at startup, the fallback logic sets `Enabled=false`. This makes the "enabled but unreachable" case look identical to "intentionally disabled" — the addon status checks, masthead, and mesh topology page all skip Prometheus entirely, so the user loses visibility into their misconfiguration.

This PR changes the behavior so that:

- **`Enabled` stays `true`** when Prometheus was requested but failed to connect. The noop client is still injected for graceful data-path degradation.
- **Addon status, masthead, and mesh page** continue to probe Prometheus and report it as unhealthy (red status), giving the user proper error visibility.
- A new **`DisabledReason`** field (already present in #9633) distinguishes the three states:
  - `enabled=true`, no `disabledReason` → fully operational
  - `enabled=true`, `disabledReason` set → wanted but unavailable (warning toast, red status)
  - `enabled=false` → explicitly disabled by user (info toast, no status probe)

### Frontend changes

- Added `isPrometheusAvailable()` helper (`enabled && !disabledReason`) in `ServerConfig.ts`, used by all feature-gating checks (tab visibility, graph empty state, metrics fetches) instead of raw `prometheus.enabled`.
- `AuthenticationController` shows a **warning** toast for unreachable Prometheus and an **info** toast for explicitly disabled.
- Added test for "enabled but unreachable" empty graph state.

### Backend changes

- `cmd/server.go`: No longer sets `Enabled=false` on startup failure; records `DisabledReason` only.
- `handlers/config.go`: Skips Prometheus config queries when `DisabledReason` is set (noop client can't return real scrape intervals).
- `handlers/config_test.go`: Updated test to reflect `Enabled=true` with `DisabledReason`.
- `config/config.go`: Updated `DisabledReason` comment for new three-state semantics.

## Test plan

- [ ] Start Kiali with Prometheus enabled and reachable → full features, no toast
- [ ] Start Kiali with Prometheus enabled but unreachable → warning toast, red masthead status, Prometheus visible on mesh page with error, metrics features hidden
- [ ] Start Kiali with `prometheus.enabled: false` → info toast, no Prometheus in status/mesh, metrics features hidden
- [ ] Verify no error toasts on graph page in either disabled scenario

Made with [Cursor](https://cursor.com)